### PR TITLE
add `#include <atomic>` to `src/udpTracker.hpp`

### DIFF
--- a/src/udpTracker.hpp
+++ b/src/udpTracker.hpp
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <list>
 #include <ctime>
+#include <atomic>
 
 #include <thread>
 #include <boost/program_options.hpp>


### PR DESCRIPTION
Without the explicit include of <atomic> from std i get the following error:
```
In file included from /tmp/nix-build-udpt-2017-09-27/src/udpTracker.hpp:166:14: error: 'atomic_bool' in namespace 'std' does not name a type
         std::atomic_bool m_shouldRun;
              ^~~~~~~~~~~
```