### PR TITLE
Dockerfile: do not hardcode `--jobs` switch when `cargo build`ing, but allow build args.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM rust:latest
+
+ARG BUILD_ARGS
+
 COPY . /usr/src/udpt
 WORKDIR /usr/src/udpt
 
-RUN cargo build --release -j4
+RUN cargo build --release ${BUILD_ARGS}
 
 CMD ["target/release/udpt-rs", "-c", "/usr/src/udpt/udpt.toml"]


### PR DESCRIPTION
When building, found that `--jobs` switch is hardcoded. This might prevent fully using available CPUs. Also, people wanting less load might prefer a smaller `-j` param.
Removed completely the `-j4`, but added a `BUILD_ARGS` [docker build argument](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg), in case anyone wants to fine-tune it.

Example (use it for testing this very same PR):
```console
docker build -t udpt --build-arg=BUILD_ARGS=-j1 github.com/pataquets/udpt#patch-1
```