### PR TITLE
Dockerfile: Use ENTRYPOINT for binary and CMD for switches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ WORKDIR /usr/src/udpt
 
 RUN cargo build --release ${BUILD_ARGS}
 
-CMD ["target/release/udpt-rs", "-c", "/usr/src/udpt/udpt.toml"]
+ENTRYPOINT [ "target/release/udpt-rs" ]
+CMD [ "-c", "/usr/src/udpt/udpt.toml" ]


### PR DESCRIPTION
As per the [ENTRYPOINT best practives](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint).

This way it's easier to specify alternate command-line switches (which will be passed via `CMD`) without having to be careful with the main executable path (which now is under `ENTRYPOINT`).

### Example: Using another config file
#### Before
``` shell
# You must be careful in preserving main executable
docker run udpt target/release/udpt-rs -c /another/config.toml
```
#### Now
```
docker run udpt -c /another/config.toml
```

----

Now you could also do:
```
docker run udpt --help
```

If no args given, `CMD` value will act as default switches, thus preserving previous behaviour.