### PR TITLE
add systemd contrib & rpm spec

### DIFF
--- a/contrib/rpm/opensuse_udpt.spec
+++ b/contrib/rpm/opensuse_udpt.spec
@@ -36,7 +36,7 @@ Provides:       user(udpt)
 UDPT is a lightweight torrent tracker that uses the UDP protocol for tracking and fully implements BEP-15. This project was developed with security & simplicity in mind, so it shouldn't be difficult to get a server started.
 
 %prep
-%autosetup -a1
+%autosetup -a1 -a2 -a3
 
 %build
 %{cargo_build}

--- a/contrib/rpm/opensuse_udpt.spec
+++ b/contrib/rpm/opensuse_udpt.spec
@@ -42,6 +42,9 @@ UDPT is a lightweight torrent tracker that uses the UDP protocol for tracking an
 %build
 %{cargo_build}
 
+%check
+cargo test --offline --verbose
+
 %install
 install -Dm 755  target/release/udpt-rs %{buildroot}%{_bindir}/udpt
 install -Dm 644  contrib/systemd/udpt.service %{buildroot}%{_unitdir}/udpt.service

--- a/contrib/rpm/opensuse_udpt.spec
+++ b/contrib/rpm/opensuse_udpt.spec
@@ -51,7 +51,7 @@ install -Dm 644  contrib/systemd/udpt.conf %{buildroot}%{_sysconfdir}/udpt.conf
 
 %files
 %license LICENSE
-%doc README.md
+%doc README.md docs/src/config.md docs/src/tracking_modes.md docs/src/api.md
 %config(noreplace) %{_sysconfdir}/udpt.conf
 %{_bindir}/udpt
 %{_unitdir}/udpt.service

--- a/contrib/rpm/opensuse_udpt.spec
+++ b/contrib/rpm/opensuse_udpt.spec
@@ -23,8 +23,8 @@ Summary:        A lightweight UDP torrent tracker
 License:        MIT
 URL:            https://github.com/naim94a/udpt
 Source0:        udpt-3.1.2.tar.zst
-Source2:        vendor.tar.zst
-Source1:        contrib.tar.zst
+Source1:        vendor.tar.zst
+Source2:        contrib.tar.zst
 BuildRequires:  cargo-packaging
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  sysuser-tools
@@ -36,7 +36,8 @@ Provides:       user(udpt)
 UDPT is a lightweight torrent tracker that uses the UDP protocol for tracking and fully implements BEP-15. This project was developed with security & simplicity in mind, so it shouldn't be difficult to get a server started.
 
 %prep
-%autosetup -a1 -a2 -a3
+%setup -qa1 -qa2
+#%%autosetup -a2 -a1
 
 %build
 %{cargo_build}
@@ -51,12 +52,13 @@ install -Dm 644  contrib/systemd/udpt.conf %{buildroot}%{_sysconfdir}/udpt.conf
 %files
 %license LICENSE
 %doc README.md
+%config(noreplace) %{_sysconfdir}/udpt.conf
 %{_bindir}/udpt
 %{_unitdir}/udpt.service
 %{_tmpfilesdir}/udpt.conf
 %{_sysusersdir}/system-user-udpt.conf
 
-%pre -f udpt.pre
+%pre
 %service_add_pre udpt.service
 
 %post
@@ -71,4 +73,3 @@ install -Dm 644  contrib/systemd/udpt.conf %{buildroot}%{_sysconfdir}/udpt.conf
 %service_del_postun udpt.service
 
 %changelog
-

--- a/contrib/rpm/opensuse_udpt.spec
+++ b/contrib/rpm/opensuse_udpt.spec
@@ -1,0 +1,74 @@
+#
+# spec file for package udpt
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           udpt
+Version:        3.1.2
+Release:        0
+Summary:        A lightweight UDP torrent tracker
+License:        MIT
+URL:            https://github.com/naim94a/udpt
+Source0:        udpt-3.1.2.tar.zst
+Source2:        vendor.tar.zst
+Source1:        contrib.tar.zst
+BuildRequires:  cargo-packaging
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  sysuser-tools
+BuildRequires:  zstd
+Provides:       user(udpt)
+%{sysusers_requires}
+
+%description
+UDPT is a lightweight torrent tracker that uses the UDP protocol for tracking and fully implements BEP-15. This project was developed with security & simplicity in mind, so it shouldn't be difficult to get a server started.
+
+%prep
+%autosetup -a1
+
+%build
+%{cargo_build}
+
+%install
+install -Dm 755  target/release/udpt-rs %{buildroot}%{_bindir}/udpt
+install -Dm 644  contrib/systemd/udpt.service %{buildroot}%{_unitdir}/udpt.service
+install -Dm 644  contrib/systemd/udpt.tmpfiles %{buildroot}%{_tmpfilesdir}/udpt.conf
+install -Dm 644  contrib/systemd/udpt.sysusers %{buildroot}%{_sysusersdir}/system-user-udpt.conf
+install -Dm 644  contrib/systemd/udpt.conf %{buildroot}%{_sysconfdir}/udpt.conf
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/udpt
+%{_unitdir}/udpt.service
+%{_tmpfilesdir}/udpt.conf
+%{_sysusersdir}/system-user-udpt.conf
+
+%pre -f udpt.pre
+%service_add_pre udpt.service
+
+%post
+%sysusers_create %{_sysusersdir}/system-user-udpt.conf
+%tmpfiles_create %{_tmpfilesdir}/udpt.conf
+%service_add_post udpt.service
+
+%preun
+%service_del_preun udpt.service
+
+%postun
+%service_del_postun udpt.service
+
+%changelog
+

--- a/contrib/systemd/udpt.conf
+++ b/contrib/systemd/udpt.conf
@@ -6,7 +6,8 @@
 #
 # [udp] section
 # This section must exist.
-# bind_address - Required. This is where the UDP port will bind to. Example: 0.0.0.0:6969. # announce_interval - Required. Sets the announce_interval that will be sent to peers (in seconds).
+# bind_address - Required. This is where the UDP port will bind to. Example: 0.0.0.0:6969.
+# announce_interval - Required. Sets the announce_interval that will be sent to peers (in seconds).
 #
 # [http] section
 # This section is optional.

--- a/contrib/systemd/udpt.conf
+++ b/contrib/systemd/udpt.conf
@@ -1,0 +1,34 @@
+# Root Level
+# mode - Required. Possbile Values: private, static or dynamic.
+# log_level - Default: info. Possible Values: off, error, warning, info, debug, trace.
+# db_path - Database path. If not set, database will be volatile.
+# cleanup_interval - Default: 600. Interval to run cleanup in seconds. Cleanup also saves the Database.
+#
+# [udp] section
+# This section must exist.
+# bind_address - Required. This is where the UDP port will bind to. Example: 0.0.0.0:6969. # announce_interval - Required. Sets the announce_interval that will be sent to peers (in seconds).
+#
+# [http] section
+# This section is optional.
+# bind_address - Required (if section exists). The HTTP REST API will be bound to this address.
+# It's best not to expose this address publically. Example: 127.0.0.1:1234.
+#
+# [http.access_tokens] section
+# Section is required if [http] section exists.
+#
+# In this section you can make up keys that would be user ids, and values that would be their access token. If this section is empty, the REST API will not be very useful.
+
+mode = "dynamic"
+db_path = "udpt_database.json.bz2"
+log_level = "info"
+cleanup_interval = 600
+
+[udp]
+announce_interval = 120
+bind_address = "0.0.0.0:1212"
+
+[http]
+bind_address = "0.0.0.0:1212"
+
+[http.access_tokens]
+someone = "MyAccessToken"

--- a/contrib/systemd/udpt.service
+++ b/contrib/systemd/udpt.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=UDPT is a lightweight torrent tracker
+Wants=network-online.target
+After=multi-user.target network.target network-online.target
+
+[Service]
+Type=simple
+User=udpt
+Group=udpt
+WorkingDirectory=/var/lib/udpt
+ExecStart=/usr/bin/udpt -c /etc/udpt.conf
+Restart=always
+RestartSec=30
+TimeoutStartSec=300
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectSystem=strict
+ProtectHome=read-only
+SystemCallFilter=~@mount
+ReadWritePaths=/var/lib/udpt
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/udpt.sysusers
+++ b/contrib/systemd/udpt.sysusers
@@ -1,0 +1,3 @@
+u udpt - "udpt user" /var/lib/udpt -
+g udpt - -
+m udpt udpt

--- a/contrib/systemd/udpt.tmpfiles
+++ b/contrib/systemd/udpt.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/udpt 700 udpt udpt


### PR DESCRIPTION
I tried to be useful and decided to do it with what I can do:

`contrib/systemd/udpt.conf` - default config with comments
`contrib/systemd/udpt.service` - systemd service unit
`contrib/systemd/udpt.sysusers` - sysuser & group
`contrib/systemd/udpt.tmpfiles` - homedir for sysuser
`contrib/rpm/opensuse_udpt.spec` - rpm spec for opensuse (i use it [here](https://build.opensuse.org/package/show/home:Werwolf2517/udpt))
